### PR TITLE
Fix NullPointerException in reload() and init() URL handling

### DIFF
--- a/common/src/main/java/me/chrommob/minestore/common/MineStoreCommon.java
+++ b/common/src/main/java/me/chrommob/minestore/common/MineStoreCommon.java
@@ -183,6 +183,10 @@ public class MineStoreCommon {
         Component message = null;
         if (!lastVerificationResult.isValid()) {
             String dump = dumper().dump(readDebugLog(), this);
+            if (dump == null) {
+                dump = "Log could not be uploaded due to network failure.";
+            }
+
             message = Component.text("If you need assitance with debugging please send the following log to the support: ").append(Component.text(dump).clickEvent(ClickEvent.openUrl(dump)));
             resetDebugLog();
         }
@@ -442,7 +446,21 @@ public class MineStoreCommon {
         for (MineStoreAddon addon : addons) {
             addonConfigs.get(addon).reloadConfig("config");
         }
+
+        String storeUrl = ConfigKeys.STORE_URL.getValue();
+        if (storeUrl != null && !storeUrl.startsWith("https://")) {
+            if (storeUrl.contains("://")) {
+                String[] prefix = storeUrl.split("://");
+                storeUrl = "https://" + prefix[1];
+            } else {
+                storeUrl = "https://" + storeUrl;
+            }
+            ConfigKeys.STORE_URL.setValue(storeUrl);
+            pluginConfig.saveConfig();
+        }
+
         apiHandler = new ApiHandler(new AuthData(ConfigKeys.STORE_URL.getValue(), ConfigKeys.API_KEYS.ENABLED.getValue(), ConfigKeys.API_KEYS.KEY.getValue()));
+
         new MineStoreReloadEvent().call();
         log("Reloading...");
         pluginConfig.reload();


### PR DESCRIPTION
Hi, 

I've fixed a NullPointerException that occurs in the `init()` method when the log dumper returns null. I also added URL sanitization to the `reload()` method to ensure that the store URL always includes the "https://" protocol, preventing connection failures during `autosetup`.

These changes ensure the plugin remains stable even if the network fails during a dump or if the user enters a domain without the protocol.

```
[07:12:56 INFO]: [MineStore] Enabling MineStore v3.7.6
[07:12:56 INFO]: [MineStore] [STDOUT] Downloading dependencies...
[07:12:56 WARN]: Nag author(s): '[ChromMob]' of 'MineStore v3.7.6' about their usage of System.out/err.print. Please use your plugin's logger instead (JavaPlugin#getLogger).
[07:12:56 INFO]: [MineStore] [STDOUT] Downloading dependencies...
[07:12:56 INFO]: [MineStore] [STDOUT] Using MineStore-Bukkit-Kyori-Native.jarjar from jars folder
[07:12:56 INFO]: [MineStore] [STDOUT] Using MineStore-Bukkit.jarjar from jars folder
[07:12:56 INFO]: [MineStore] [STDOUT] Downloading dependencies...
[07:12:56 INFO]: [MineStore] [STDOUT] Downloading dependencies...
[07:12:56 INFO]: [MineStore] [STDOUT] Using MineStore-Common.jarjar from jars folder
[07:12:56 INFO]: [MineStore] Using modern command manager.
[07:12:57 INFO]: [MineStore] Failed to dump log
[07:12:57 WARN]: java.lang.NullPointerException: Cannot invoke "String.isEmpty()" because "content" is null
[07:12:57 WARN]:        at net.kyori.adventure.text.Component.text(Component.java:807)
[07:12:57 WARN]:        at me.chrommob.minestore.common.MineStoreCommon.init(MineStoreCommon.java:186)
[07:12:57 WARN]:        at me.chrommob.minestore.platforms.bukkit.MineStoreBukkit.onEnable(MineStoreBukkit.java:133)
[07:12:57 WARN]:        at MineStore-3.7.6.jar//me.chrommob.minestore.platforms.bukkit.MineStoreBukkitPlugin.onEnable(MineStoreBukkitPlugin.java:36)
[07:12:57 WARN]:        at org.bukkit.plugin.java.JavaPlugin.setEnabled(JavaPlugin.java:280)
[07:12:57 WARN]:        at io.papermc.paper.plugin.manager.PaperPluginInstanceManager.enablePlugin(PaperPluginInstanceManager.java:202)
[07:12:57 WARN]:        at io.papermc.paper.plugin.manager.PaperPluginManagerImpl.enablePlugin(PaperPluginManagerImpl.java:109)
[07:12:57 WARN]:        at org.bukkit.plugin.SimplePluginManager.enablePlugin(SimplePluginManager.java:520)
[07:12:57 WARN]:        at org.bukkit.craftbukkit.CraftServer.enablePlugin(CraftServer.java:652)
[07:12:57 WARN]:        at org.bukkit.craftbukkit.CraftServer.enablePlugins(CraftServer.java:608)
[07:12:57 WARN]:        at net.minecraft.server.MinecraftServer.loadWorld0(MinecraftServer.java:743)
[07:12:57 WARN]:        at net.minecraft.server.MinecraftServer.loadLevel(MinecraftServer.java:488)
[07:12:57 WARN]:        at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:280)
[07:12:57 WARN]:        at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1164)
[07:12:57 WARN]:        at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:310)
[07:12:57 WARN]:        at java.base/java.lang.Thread.run(Thread.java:1583)
[07:12:57 WARN]: [org.mineskin.MineSkinClient] Creating MineSkinClient without API key
```